### PR TITLE
Add Outreach instructions to Facilitator documentation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,4 +14,7 @@ links:
   # The "ISPO Working Group" folder.
   folder: https://drive.google.com/drive/folders/1vFJPuQ5l0hKIlC58qjdV1MNSIhdoSBCz
 
-remote_theme: InnerSourceCommons/working-group-roles
+  # Attendance sheet.
+  attendance: https://docs.google.com/spreadsheets/d/1YNTpX-e7s2YQhjgWgSyr_9I_EO3NIqFVMiMbsGkgVrA/edit?usp=sharing
+
+remote_theme: InnerSourceCommons/working-group-roles@rrrutledge-patch-2

--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ links:
   # The "ISPO Working Group" folder.
   folder: https://drive.google.com/drive/folders/1vFJPuQ5l0hKIlC58qjdV1MNSIhdoSBCz
 
-  # Attendance sheet.
+  # Our Google Sheets attendance.
   attendance: https://docs.google.com/spreadsheets/d/1YNTpX-e7s2YQhjgWgSyr_9I_EO3NIqFVMiMbsGkgVrA/edit?usp=sharing
 
-remote_theme: InnerSourceCommons/working-group-roles@rrrutledge-patch-2
+remote_theme: InnerSourceCommons/working-group-roles


### PR DESCRIPTION
* Needs https://github.com/InnerSourceCommons/working-group-roles/pull/5 merged first.
* Check this out working at https://innersourcecommons.github.io/ispo-working-group/roles/facilitator.html.
* After this is merged, updated our [Pages configuration](https://github.com/InnerSourceCommons/ispo-working-group/settings/pages) to deploy from _main_.