### PR TITLE
Update adding-trusted-committers.md

### DIFF
--- a/docs/adding-trusted-committers.md
+++ b/docs/adding-trusted-committers.md
@@ -7,7 +7,8 @@ This document describes how to add a new Trusted Committer to the ISPO Working G
 5. Update the ["Trusted Committers" section of the README](../README.md#trusted-committers) to list the new person.
 6. Invite the person into the [#ispo-working-group-trusted-committers] _Slack_ channel.
 7. Add the person to the [@InnerSourceCommons/ispo-working-group-trusted-committers] _GitHub_ team.
-8. Give a shout-out and congratulations to the person in the [#ispo-working-group] channel for becoming a Trusted Committer.
+8. Make the person an owner of the [@InnerSourceCommons/ispo-working-group-trusted-committers] _GitHub_ team.
+9. Give a shout-out and congratulations to the person in the [#ispo-working-group] channel for becoming a Trusted Committer.
 
 [#ispo-working-group-trusted-committers]: https://app.slack.com/client/T04PXKRM0/C05QTAZC5PZ
 [#ispo-working-group]: https://app.slack.com/client/T04PXKRM0/C04DT6NQX7G


### PR DESCRIPTION
Make the person an owner of the @InnerSourceCommons/ispo-working-group-trusted-committers GitHub team (so they can add new Trusted Committers in the future).