### PR TITLE
Enhancement: Added link to meeting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,4 +19,7 @@ links:
   # Our Google Sheets attendance.
   attendance: https://docs.google.com/spreadsheets/d/1YNTpX-e7s2YQhjgWgSyr_9I_EO3NIqFVMiMbsGkgVrA/edit?usp=sharing
 
+  # Link to join our regular meeting
+  meeting_link: https://meet.jit.si/ISPOWorkingGroup
+
 remote_theme: InnerSourceCommons/working-group-roles


### PR DESCRIPTION
Follow up of the new feature of the theme https://github.com/InnerSourceCommons/working-group-roles which allows us to indicate a link to join the meeting on the documentation of the _Crier_ role.

Related pull requests:
- https://github.com/InnerSourceCommons/working-group-roles/pull/9

Result:
<img width="846" alt="image" src="https://github.com/InnerSourceCommons/ispo-working-group/assets/54676965/6d96cdfa-3d12-48af-8830-3d2cc31859b8">
